### PR TITLE
Remove hard-coded API secrets

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,28 @@
+# Backend settings
+DEBUG=True
+SECRET_KEY=
+ALLOWED_HOSTS=localhost,127.0.0.1
+
+# API keys
+REDDIT_CLIENT_ID=
+REDDIT_CLIENT_SECRET=
+REDDIT_USER_AGENT=buzznet/1.0
+TWITTER_API_KEY=
+TWITTER_API_SECRET=
+TWITTER_BEARER_TOKEN=
+GNEWS_IO_KEY=
+NEWSAPI_IO_KEY=
+
+# Database settings
+DB_NAME=postgres
+DB_USER=postgres
+DB_PASSWORD=postgres
+DB_HOST=db
+DB_PORT=5432
+
+# Redis settings
+REDIS_HOST=redis
+REDIS_PORT=6379
+
+# Frontend settings
+REACT_APP_API_URL=http://localhost:8000

--- a/README.md
+++ b/README.md
@@ -37,3 +37,14 @@ This launches the backend at `http://localhost:8000` and the frontend at `http:/
   ```
 
 For additional Docker notes see `DOCKER_README.md`.
+
+## Environment Variables
+
+Copy `.env.example` to `.env` and provide your API keys before running the
+application. Important variables include:
+
+- `REDDIT_CLIENT_ID` and `REDDIT_CLIENT_SECRET` – Reddit credentials
+- `REDDIT_USER_AGENT` – optional user agent for Reddit API requests
+- `TWITTER_API_KEY`, `TWITTER_API_SECRET` and `TWITTER_BEARER_TOKEN`
+- `GNEWS_IO_KEY` and `NEWSAPI_IO_KEY`
+- Standard Django settings such as `SECRET_KEY`, database and Redis options

--- a/backend-pipeline/BackendTests/pipeline/reddit_api.py
+++ b/backend-pipeline/BackendTests/pipeline/reddit_api.py
@@ -1,9 +1,10 @@
+import os
 import praw
 
-# Your Reddit API credentials
-CLIENT_ID = "QtpJhmymZH1H4k-c3nbFYQ"
-CLIENT_SECRET = "IIJc1uQbf_mGyAL_fgzclcYPljFuAQ"
-USER_AGENT = "buzznet/1.0"
+# Load Reddit API credentials from environment variables
+CLIENT_ID = os.environ.get("REDDIT_CLIENT_ID")
+CLIENT_SECRET = os.environ.get("REDDIT_CLIENT_SECRET")
+USER_AGENT = os.environ.get("REDDIT_USER_AGENT", "buzznet/1.0")
 
 # Initialize the Reddit API client
 reddit = praw.Reddit(

--- a/backend-pipeline/BackendTests/pipeline/twitter_api.py
+++ b/backend-pipeline/BackendTests/pipeline/twitter_api.py
@@ -1,9 +1,10 @@
+import os
 import tweepy
 
-# Your Twitter API credentials
-API_KEY = "qeZKAmaXsOefzgDF0PEdbxaJj"
-API_SECRET = "wKpHbTEDMUiTDwp1lpX7efVDGEfueNZk3AABrwDMXqbXk3hCOE"
-BEARER_TOKEN = "AAAAAAAAAAAAAAAAAAAAAMfOkAEAAAAAadjUpvtiNd3xES3xgukYR%2Bu3Pr0%3DECLXvPyPmDTKK1tcX7UwETQrHhGztyMKyuF496fRT9VjffpTMU"
+# Load Twitter API credentials from environment variables
+API_KEY = os.environ.get("TWITTER_API_KEY")
+API_SECRET = os.environ.get("TWITTER_API_SECRET")
+BEARER_TOKEN = os.environ.get("TWITTER_BEARER_TOKEN")
 
 # Authenticate
 client = tweepy.Client(bearer_token=BEARER_TOKEN)

--- a/backend-pipeline/djangoBackend/settings.py
+++ b/backend-pipeline/djangoBackend/settings.py
@@ -18,10 +18,9 @@ import os
 # Assuming your .env file is in the same directory as your manage.py
 #load_dotenv()  # This will load variables from your project's root .env file
 
-# GNEWS_API_KEY = os.getenv('GNEWS_IO_KEY')
-# NEWSAPI_KEY = os.getenv('NEWSAPI_IO_KEY')
-GNEWS_IO_KEY='a7b501c964b0ac3f412cedabf6d035cc'
-NEWSAPI_IO_KEY='tQEhUNGhJmIMvqwqPxz5CmT2QYXNu6svPr7fO0fj'
+# Load API keys from environment variables
+GNEWS_IO_KEY = os.environ.get('GNEWS_IO_KEY')
+NEWSAPI_IO_KEY = os.environ.get('NEWSAPI_IO_KEY')
 
 
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -33,7 +32,7 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 # See https://docs.djangoproject.com/en/5.1/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = 'django-insecure-fm7io5^0k6$q=f@4)457yw7(q$(1c38i6i512s2@xm#7#=k9mq'
+SECRET_KEY = os.environ.get('SECRET_KEY')
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True


### PR DESCRIPTION
## Summary
- read API credentials from env in Reddit and Twitter test clients
- load Django secrets from env variables
- document required variables
- add `.env.example` template

## Testing
- `python backend-pipeline/manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_683fd6859990832795e01c056a485efe